### PR TITLE
[DEV-166] Inclusão da chamada da home

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.4.10'
+    ext.kotlin_version = '1.4.30'
 
     repositories {
         google()
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath 'com.android.tools.build:gradle:4.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+    id "com.android.library"
+    id "kotlin-android"
+}
 
 android {
     compileSdkVersion 30
@@ -29,7 +31,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
     // SERVICES
-    api 'com.squareup.retrofit2:retrofit:2.9.0'
+    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
     implementation 'com.squareup.retrofit2:adapter-rxjava2:2.9.0'
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     implementation 'io.reactivex.rxjava2:rxjava:2.2.19'
@@ -39,7 +41,7 @@ dependencies {
     implementation 'com.github.chain-partners:KotlinPhoenixChannel:0.1.15'
 
     // TEST
-    testImplementation 'junit:junit:4.13'
+    testImplementation 'junit:junit:4.13.1'
     testImplementation 'org.jetbrains.kotlinx:kotlinx-coroutines-test:1.3.9'
     testImplementation 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0'
     testImplementation 'org.mockito:mockito-inline:3.5.13'
@@ -49,10 +51,10 @@ dependencies {
 
     // GENERAL
     implementation "androidx.appcompat:appcompat:1.2.0"
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.10'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.4.30'
 
     // COROUTINES
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
 }
 
 repositories {

--- a/sdk/src/main/java/com/ingresse/sdk/IngresseService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/IngresseService.kt
@@ -26,6 +26,7 @@ import com.ingresse.sdk.services.WebSocketService
 import com.ingresse.sdk.services.ZipCodeService
 import com.ingresse.sdk.v2.repositories.EventDetails
 import com.ingresse.sdk.v2.repositories.Highlights
+import com.ingresse.sdk.v2.repositories.Home
 import com.ingresse.sdk.v2.repositories.Search
 import com.ingresse.sdk.v2.repositories.UserWallet
 
@@ -60,5 +61,6 @@ class IngresseService(var client: IngresseClient) {
         override val search = Search(client)
         override val eventDetails = EventDetails(client)
         override val userWallet = UserWallet(client)
+        override val home = Home(client)
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/IngresseService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/IngresseService.kt
@@ -27,6 +27,8 @@ import com.ingresse.sdk.services.ZipCodeService
 import com.ingresse.sdk.v2.repositories.EventDetails
 import com.ingresse.sdk.v2.repositories.Highlights
 import com.ingresse.sdk.v2.repositories.Home
+import com.ingresse.sdk.v2.repositories.Password
+import com.ingresse.sdk.v2.repositories.PasswordStrength
 import com.ingresse.sdk.v2.repositories.Search
 import com.ingresse.sdk.v2.repositories.UserWallet
 
@@ -62,5 +64,7 @@ class IngresseService(var client: IngresseClient) {
         override val eventDetails = EventDetails(client)
         override val userWallet = UserWallet(client)
         override val home = Home(client)
+        override val password = Password(client)
+        override val passwordStrength = PasswordStrength(client)
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/V2Services.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/V2Services.kt
@@ -2,6 +2,7 @@ package com.ingresse.sdk
 
 import com.ingresse.sdk.v2.repositories.EventDetails
 import com.ingresse.sdk.v2.repositories.Highlights
+import com.ingresse.sdk.v2.repositories.Home
 import com.ingresse.sdk.v2.repositories.Search
 import com.ingresse.sdk.v2.repositories.UserWallet
 
@@ -10,4 +11,5 @@ interface V2Services {
     val search: Search
     val eventDetails: EventDetails
     val userWallet: UserWallet
+    val home: Home
 }

--- a/sdk/src/main/java/com/ingresse/sdk/V2Services.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/V2Services.kt
@@ -3,6 +3,8 @@ package com.ingresse.sdk
 import com.ingresse.sdk.v2.repositories.EventDetails
 import com.ingresse.sdk.v2.repositories.Highlights
 import com.ingresse.sdk.v2.repositories.Home
+import com.ingresse.sdk.v2.repositories.Password
+import com.ingresse.sdk.v2.repositories.PasswordStrength
 import com.ingresse.sdk.v2.repositories.Search
 import com.ingresse.sdk.v2.repositories.UserWallet
 
@@ -12,4 +14,6 @@ interface V2Services {
     val eventDetails: EventDetails
     val userWallet: UserWallet
     val home: Home
+    val password: Password
+    val passwordStrength: PasswordStrength
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/AuthService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/AuthService.kt
@@ -241,6 +241,16 @@ class AuthService(private val client: IngresseClient) {
      * @param onConnectionError - connection error callback
      * @param onTokenExpired - token expired callback
      */
+    @Deprecated(
+        message = "This call will no longer be maintained. Use V2 replacements.",
+        replaceWith = ReplaceWith(
+            expression = "Password(client).requestReset(request = RequestReset())",
+            imports = [
+                "com.ingresse.sdk.v2.repositories",
+                "com.ingresse.sdk.v2.models.request.RequestReset",
+            ]
+        )
+    )
     fun recoverPassword(email: String, onSuccess: (AuthPasswordJSON) -> Unit, onError: ErrorBlock, onConnectionError: (Throwable) -> Unit, onTokenExpired: Block) {
         mRecoverPasswordCall = service.recoverPassword(
                 apikey = client.key,
@@ -279,6 +289,16 @@ class AuthService(private val client: IngresseClient) {
      * @param onConnectionError - connection error callback
      * @param onTokenExpired - token expired callback
      */
+    @Deprecated(
+        message = "This call will no longer be maintained. Use V2 replacements.",
+        replaceWith = ReplaceWith(
+            expression = "Password(client).validateHash(request = ValidateHash())",
+            imports = [
+                "com.ingresse.sdk.v2.repositories",
+                "com.ingresse.sdk.v2.models.request.ValidateHash",
+            ]
+        )
+    )
     fun validateHash(request: ValidateHash, onSuccess: (ValidateHashJSON) -> Unit, onError: ErrorBlock, onConnectionError: (Throwable) -> Unit, onTokenExpired: Block) {
         mValidateHashCall = service.validateHash(
                 apikey = client.key,
@@ -318,6 +338,16 @@ class AuthService(private val client: IngresseClient) {
      * @param onConnectionError - connection error callback
      * @param onTokenExpired - token expired callback
      */
+    @Deprecated(
+        message = "This call will no longer be maintained. Use V2 replacements.",
+        replaceWith = ReplaceWith(
+            expression = "Password(client).updatePassword(request = UpdatePassword())",
+            imports = [
+                "com.ingresse.sdk.v2.repositories",
+                "com.ingresse.sdk.v2.models.request.UpdatePassword",
+            ]
+        )
+    )
     fun updatePassword(request: UpdatePassword, onSuccess: (AuthPasswordJSON) -> Unit, onError: ErrorBlock, onConnectionError: (Throwable) -> Unit, onTokenExpired: Block) {
         mUpdatePasswordCall = service.updatePassword(
                 apikey = client.key,

--- a/sdk/src/main/java/com/ingresse/sdk/services/UserService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/UserService.kt
@@ -588,6 +588,16 @@ class UserService(private val client: IngresseClient) {
      * @param onConnectionError - connection error callback
      * @param onTokenExpired - user token expired callback
      */
+    @Deprecated(
+        message = "This call will no longer be maintained. Use V2 replacements.",
+        replaceWith = ReplaceWith(
+            expression = "PasswordStrength(client).validateStrength(request = PasswordStrength())",
+            imports = [
+                "com.ingresse.sdk.v2.repositories",
+                "com.ingresse.sdk.v2.models.request.PasswordStrength",
+            ]
+        )
+    )
     fun validatePasswordStrength(request: String,
                                  onSuccess: (StrengthPasswordJSON) -> Unit,
                                  onError: ErrorBlock,

--- a/sdk/src/main/java/com/ingresse/sdk/v2/defaults/URLs.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/defaults/URLs.kt
@@ -1,0 +1,8 @@
+package com.ingresse.sdk.v2.defaults
+
+class URLs {
+
+    object Home {
+        const val CATEGORIES = "https://qhb3ijfna4.execute-api.us-east-1.amazonaws.com"
+    }
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/base/RegularData.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/base/RegularData.kt
@@ -1,0 +1,5 @@
+package com.ingresse.sdk.v2.models.base
+
+data class RegularData<T>(
+    val data: T
+)

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/request/Password.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/request/Password.kt
@@ -1,0 +1,14 @@
+package com.ingresse.sdk.v2.models.request
+
+data class RequestReset(val email: String)
+
+data class ValidateHash(
+    var email: String,
+    var hash: String,
+)
+
+data class UpdatePassword(
+    var email: String,
+    var password: String,
+    var hash: String,
+)

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/request/ValidateStrength.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/request/ValidateStrength.kt
@@ -1,0 +1,3 @@
+package com.ingresse.sdk.v2.models.request
+
+data class ValidateStrength(val password: String)

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/response/HomeJSON.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/response/HomeJSON.kt
@@ -1,0 +1,19 @@
+package com.ingresse.sdk.v2.models.response
+
+data class HomeJSON(
+    val categories: CategoriesJSON,
+) {
+
+    data class CategoriesJSON(
+        val visible: List<Items>,
+        val hidden: List<Items>
+    ) {
+
+        data class Items(
+            val id: Int,
+            val category: String,
+            val slug: String,
+            val totalItems: Int,
+        )
+    }
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/response/HomeJSON.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/response/HomeJSON.kt
@@ -10,9 +10,9 @@ data class HomeJSON(
     ) {
 
         data class Items(
-            val id: Int,
+            val id: Int?,
             val category: String,
-            val slug: String,
+            val slug: String?,
             val totalItems: Int,
         )
     }

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/response/PasswordStrengthJSON.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/response/PasswordStrengthJSON.kt
@@ -1,0 +1,20 @@
+package com.ingresse.sdk.v2.models.response
+
+data class PasswordStrengthJSON(
+    var secure: Boolean?,
+    var score: PasswordScoreJSON?,
+    var info: PasswordInfoJSON?,
+) {
+
+    data class PasswordScoreJSON(
+        var max: Int?,
+        var min: Int?,
+        var minAcceptable: Int?,
+        var password: Int?,
+    )
+
+    data class PasswordInfoJSON(
+        var compromised: String?,
+        var passwordStrength: String?,
+    )
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/response/password/PasswordResetJSON.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/response/password/PasswordResetJSON.kt
@@ -1,0 +1,6 @@
+package com.ingresse.sdk.v2.models.response.password
+
+data class PasswordResetJSON(
+    var status: Boolean?,
+    var message: String?,
+)

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/response/password/ValidateHashJSON.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/response/password/ValidateHashJSON.kt
@@ -1,0 +1,3 @@
+package com.ingresse.sdk.v2.models.response.password
+
+data class ValidateHashJSON(var isValid: Boolean?)

--- a/sdk/src/main/java/com/ingresse/sdk/v2/repositories/EventDetails.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/repositories/EventDetails.kt
@@ -59,7 +59,7 @@ class EventDetails(private val client: IngresseClient) {
         return responseParser(dispatcher, type) {
             service.getEventDetailsByLink(
                 apikey = client.key,
-                method = request.link,
+                method = request.method,
                 link = request.link,
                 fields = request.fields
             )

--- a/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Home.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Home.kt
@@ -1,0 +1,43 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.google.gson.reflect.TypeToken
+import com.ingresse.sdk.IngresseClient
+import com.ingresse.sdk.builders.ClientBuilder
+import com.ingresse.sdk.v2.defaults.URLs
+import com.ingresse.sdk.v2.models.base.RegularData
+import com.ingresse.sdk.v2.models.response.HomeJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.responseParser
+import com.ingresse.sdk.v2.services.HomeService
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
+
+class Home(client: IngresseClient) {
+
+    private val service: HomeService
+
+    init {
+        val httpClient = ClientBuilder(client)
+            .addRequestHeaders()
+            .build()
+
+        val adapter = Retrofit.Builder()
+            .client(httpClient)
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .baseUrl(URLs.Home.CATEGORIES)
+            .build()
+
+        service = adapter.create(HomeService::class.java)
+    }
+
+    suspend fun getHomeCategories(
+        dispatcher: CoroutineDispatcher = Dispatchers.Default,
+    ): Result<RegularData<HomeJSON>> {
+        val type = object : TypeToken<RegularData<HomeJSON>>() {}.type
+        return responseParser(dispatcher, type) {
+            service.getHomeCategories()
+        }
+    }
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Password.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Password.kt
@@ -1,0 +1,80 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.google.gson.reflect.TypeToken
+import com.ingresse.sdk.IngresseClient
+import com.ingresse.sdk.builders.ClientBuilder
+import com.ingresse.sdk.builders.Host
+import com.ingresse.sdk.builders.URLBuilder
+import com.ingresse.sdk.v2.models.base.IngresseResponse
+import com.ingresse.sdk.v2.models.request.RequestReset
+import com.ingresse.sdk.v2.models.request.UpdatePassword
+import com.ingresse.sdk.v2.models.request.ValidateHash
+import com.ingresse.sdk.v2.models.response.password.PasswordResetJSON
+import com.ingresse.sdk.v2.models.response.password.ValidateHashJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.responseParser
+import com.ingresse.sdk.v2.services.PasswordService
+import kotlinx.coroutines.CoroutineDispatcher
+import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
+
+class Password(private val client: IngresseClient) {
+
+    private val service: PasswordService
+
+    init {
+        val httpClient = ClientBuilder(client)
+            .addRequestHeaders()
+            .build()
+
+        val adapter = Retrofit.Builder()
+            .client(httpClient)
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .baseUrl(URLBuilder(Host.API, client.environment).build())
+            .build()
+
+        service = adapter.create(PasswordService::class.java)
+    }
+
+    suspend fun requestReset(
+        dispatcher: CoroutineDispatcher,
+        request: RequestReset,
+    ): Result<IngresseResponse<PasswordResetJSON>> {
+        val type = object : TypeToken<IngresseResponse<PasswordResetJSON>>() {}.type
+        return responseParser(dispatcher, type) {
+            service.requestReset(
+                apikey = client.key,
+                email = request.email
+            )
+        }
+    }
+
+    suspend fun validateHash(
+        dispatcher: CoroutineDispatcher,
+        request: ValidateHash,
+    ): Result<IngresseResponse<ValidateHashJSON>> {
+        val type = object : TypeToken<IngresseResponse<ValidateHashJSON>>() {}.type
+        return responseParser(dispatcher, type) {
+            service.validateHash(
+                apikey = client.key,
+                email = request.email,
+                hash = request.hash
+            )
+        }
+    }
+
+    suspend fun updatePassword(
+        dispatcher: CoroutineDispatcher,
+        request: UpdatePassword,
+    ): Result<IngresseResponse<PasswordResetJSON>> {
+        val type = object : TypeToken<IngresseResponse<PasswordResetJSON>>() {}.type
+        return responseParser(dispatcher, type) {
+            service.updatePassword(
+                apikey = client.key,
+                email = request.email,
+                password = request.password,
+                hash = request.hash
+            )
+        }
+    }
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/repositories/PasswordStrength.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/repositories/PasswordStrength.kt
@@ -1,0 +1,48 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.google.gson.reflect.TypeToken
+import com.ingresse.sdk.IngresseClient
+import com.ingresse.sdk.builders.ClientBuilder
+import com.ingresse.sdk.builders.Host
+import com.ingresse.sdk.builders.URLBuilder
+import com.ingresse.sdk.v2.models.base.IngresseResponse
+import com.ingresse.sdk.v2.models.request.ValidateStrength
+import com.ingresse.sdk.v2.models.response.PasswordStrengthJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.responseParser
+import com.ingresse.sdk.v2.services.PasswordStrengthService
+import kotlinx.coroutines.CoroutineDispatcher
+import retrofit2.Retrofit
+import retrofit2.converter.scalars.ScalarsConverterFactory
+
+class PasswordStrength(private val client: IngresseClient) {
+
+    private val service: PasswordStrengthService
+
+    init {
+        val httpClient = ClientBuilder(client)
+            .addRequestHeaders()
+            .build()
+
+        val adapter = Retrofit.Builder()
+            .client(httpClient)
+            .addConverterFactory(ScalarsConverterFactory.create())
+            .baseUrl(URLBuilder(Host.API, client.environment).build())
+            .build()
+
+        service = adapter.create(PasswordStrengthService::class.java)
+    }
+
+    suspend fun validateStrength(
+        dispatcher: CoroutineDispatcher,
+        request: ValidateStrength,
+    ): Result<IngresseResponse<PasswordStrengthJSON>> {
+        val type = object : TypeToken<IngresseResponse<PasswordStrengthJSON>>() {}.type
+        return responseParser(dispatcher, type) {
+            service.validatePasswordStrength(
+                apikey = client.key,
+                password = request.password
+            )
+        }
+    }
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/services/HomeService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/services/HomeService.kt
@@ -1,0 +1,13 @@
+package com.ingresse.sdk.v2.services
+
+import retrofit2.Response
+import retrofit2.http.GET
+
+interface HomeService {
+
+    /**
+     *  Get all categories available to show in home app section
+     */
+    @GET("/home")
+    suspend fun getHomeCategories(): Response<String>
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/services/PasswordService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/services/PasswordService.kt
@@ -1,0 +1,52 @@
+package com.ingresse.sdk.v2.services
+
+import retrofit2.Response
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface PasswordService {
+
+    /**
+     * Recover user password
+     *
+     * @param email - user email
+     */
+    @FormUrlEncoded
+    @POST("/recover-password")
+    suspend fun requestReset(
+        @Query("apikey") apikey: String,
+        @Field("email") email: String,
+    ): Response<String>
+
+    /**
+     * Validate hash from email sent in recover password action
+     *
+     * @param email - user email
+     * @param hash - hash received from email
+     */
+    @FormUrlEncoded
+    @POST("/recover-validate")
+    suspend fun validateHash(
+        @Query("apikey") apikey: String,
+        @Field("email") email: String,
+        @Field("hash") hash: String,
+    ): Response<String>
+
+    /**
+     * Update user password
+     *
+     * @param email - user email
+     * @param password - password to update
+     * @param hash - hash received from email
+     */
+    @FormUrlEncoded
+    @POST("/recover-update-password")
+    suspend fun updatePassword(
+        @Query("apikey") apikey: String,
+        @Field("email") email: String,
+        @Field("password") password: String,
+        @Field("hash") hash: String,
+    ): Response<String>
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/services/PasswordStrengthService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/services/PasswordStrengthService.kt
@@ -1,0 +1,19 @@
+package com.ingresse.sdk.v2.services
+
+import retrofit2.Response
+import retrofit2.http.POST
+import retrofit2.http.Query
+
+interface PasswordStrengthService {
+
+    /**
+     * Validate password strength
+     *
+     * @param password - password to be validated
+     */
+    @POST("/password")
+    suspend fun validatePasswordStrength(
+        @Query("apikey") apikey: String,
+        @Query("password") password: String,
+    ): Response<String>
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/repositories/HomeTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/repositories/HomeTest.kt
@@ -1,0 +1,164 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.ingresse.sdk.v2.models.base.RegularData
+import com.ingresse.sdk.v2.models.response.HomeJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.model.onError
+import com.ingresse.sdk.v2.parses.model.onSuccess
+import com.ingresse.sdk.v2.parses.model.onTokenExpired
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+
+@ExperimentalCoroutinesApi
+class HomeTest {
+
+    @Mock
+    val dispatcher = TestCoroutineDispatcher()
+
+    @Mock
+    val categoriesVisibleItemMock = mock<HomeJSON.CategoriesJSON.Items> {
+        Mockito.`when`(mock.id).thenReturn(123)
+        Mockito.`when`(mock.category).thenReturn("test visible category")
+        Mockito.`when`(mock.slug).thenReturn("test visible slug")
+        Mockito.`when`(mock.totalItems).thenReturn(1)
+    }
+
+    @Mock
+    val categoriesHiddenItemMock = mock<HomeJSON.CategoriesJSON.Items> {
+        Mockito.`when`(mock.id).thenReturn(456)
+        Mockito.`when`(mock.category).thenReturn("test hidden category")
+        Mockito.`when`(mock.slug).thenReturn("test hidden slug")
+        Mockito.`when`(mock.totalItems).thenReturn(1)
+    }
+
+    @Mock
+    val categoriesJsonMock = mock<HomeJSON.CategoriesJSON> {
+        Mockito.`when`(mock.visible)
+            .thenReturn(listOf(categoriesVisibleItemMock))
+        Mockito.`when`(mock.hidden)
+            .thenReturn(listOf(categoriesHiddenItemMock))
+    }
+
+    @Mock
+    val homeJsonMock = mock<HomeJSON> {
+        Mockito.`when`(mock.categories).thenReturn(categoriesJsonMock)
+    }
+
+    @Mock
+    val dataJson = mock<RegularData<HomeJSON>> {
+        Mockito.`when`(mock.data).thenReturn(homeJsonMock)
+    }
+
+    @Test
+    fun getHomeCategories_SuccessTest() {
+        val resultMock = Result.success(dataJson)
+
+        val repositoryMock = mock<Home> {
+            onBlocking {
+                getHomeCategories(dispatcher)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getHomeCategories(dispatcher)
+
+            result.onSuccess {
+                val jsonVisibleResult = it.data.categories.visible
+
+                Assert.assertEquals(123, jsonVisibleResult.first().id)
+                Assert.assertEquals("test visible category", jsonVisibleResult.first().category)
+                Assert.assertEquals("test visible slug", jsonVisibleResult.first().slug)
+                Assert.assertEquals(1, jsonVisibleResult.first().totalItems)
+
+                val jsonHiddenResult = it.data.categories.hidden
+
+                Assert.assertEquals(456, jsonHiddenResult.first().id)
+                Assert.assertEquals("test hidden category", jsonHiddenResult.first().category)
+                Assert.assertEquals("test hidden slug", jsonHiddenResult.first().slug)
+                Assert.assertEquals(1, jsonHiddenResult.first().totalItems)
+            }
+
+            Assert.assertTrue(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getHomeCategories_FailTest() {
+        val resultMock: Result<RegularData<HomeJSON>> =
+            Result.error(400, Throwable("Thrown an exception"))
+
+        val repositoryMock = mock<Home> {
+            onBlocking {
+                getHomeCategories(dispatcher)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getHomeCategories(dispatcher)
+            result.onError { code, throwable ->
+                Assert.assertEquals(400, code)
+                Assert.assertEquals("Thrown an exception", throwable.message)
+            }
+
+            Assert.assertTrue(result.isFailure)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getHomeCategories_ConnectionErrorTest() {
+        val resultMock: Result<RegularData<HomeJSON>> =
+            Result.connectionError()
+
+        val repositoryMock = mock<Home> {
+            onBlocking {
+                getHomeCategories(dispatcher)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getHomeCategories(dispatcher)
+
+            Assert.assertTrue(result.isConnectionError)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getHomeCategories_TokenExpiredTest() {
+        val resultMock: Result<RegularData<HomeJSON>> =
+            Result.tokenExpired(1234)
+
+        val repositoryMock = mock<Home> {
+            onBlocking {
+                getHomeCategories(dispatcher)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getHomeCategories(dispatcher)
+            result.onTokenExpired { code ->
+                Assert.assertEquals(1234, code)
+            }
+
+            Assert.assertTrue(result.isTokenExpired)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+        }
+    }
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/repositories/PasswordStrengthTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/repositories/PasswordStrengthTest.kt
@@ -1,0 +1,130 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.ingresse.sdk.v2.models.base.IngresseResponse
+import com.ingresse.sdk.v2.models.request.ValidateStrength
+import com.ingresse.sdk.v2.models.response.PasswordStrengthJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.model.onError
+import com.ingresse.sdk.v2.parses.model.onSuccess
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+
+@ExperimentalCoroutinesApi
+class PasswordStrengthTest {
+
+    @Mock
+    val dispatcher = TestCoroutineDispatcher()
+
+    @Mock
+    val requestMock = mock<ValidateStrength>()
+
+    @Mock
+    val scoreMock = mock<PasswordStrengthJSON.PasswordScoreJSON> {
+        `when`(mock.max).thenReturn(4)
+        `when`(mock.min).thenReturn(0)
+        `when`(mock.minAcceptable).thenReturn(2)
+        `when`(mock.password).thenReturn(0)
+    }
+
+    @Mock
+    val infoMock = mock<PasswordStrengthJSON.PasswordInfoJSON> {
+        `when`(mock.compromised).thenReturn("compromised")
+        `when`(mock.passwordStrength).thenReturn("strength")
+    }
+
+    @Mock
+    val strengthMock = mock<PasswordStrengthJSON> {
+        `when`(mock.secure).thenReturn(true)
+        `when`(mock.info).thenReturn(infoMock)
+        `when`(mock.score).thenReturn(scoreMock)
+    }
+
+    @Mock
+    val ingresseResponseMock = mock<IngresseResponse<PasswordStrengthJSON>> {
+        `when`(mock.responseData).thenReturn(strengthMock)
+    }
+
+    @Test
+    fun validatePassword_SuccessTest() {
+        val resultMock = Result.success(ingresseResponseMock)
+
+        val repositoryMock = mock<PasswordStrength> {
+            onBlocking {
+                validateStrength(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.validateStrength(dispatcher, requestMock)
+            result.onSuccess {
+                val jsonResult = it.responseData
+
+                Assert.assertEquals("compromised", jsonResult?.info?.compromised)
+                Assert.assertEquals("strength", jsonResult?.info?.passwordStrength)
+                Assert.assertEquals(4, jsonResult?.score?.max)
+                Assert.assertEquals(0, jsonResult?.score?.min)
+                Assert.assertEquals(2, jsonResult?.score?.minAcceptable)
+                Assert.assertEquals(0, jsonResult?.score?.password)
+                Assert.assertTrue(jsonResult?.secure == true)
+            }
+
+            Assert.assertTrue(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun validatePassword_FailTest() {
+        val resultMock: Result<IngresseResponse<PasswordStrengthJSON>> =
+            Result.error(400, Throwable("Thrown an exception"))
+
+        val repositoryMock = mock<PasswordStrength> {
+            onBlocking {
+                validateStrength(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.validateStrength(dispatcher, requestMock)
+            result.onError { code, throwable ->
+                Assert.assertEquals(400, code)
+                Assert.assertEquals("Thrown an exception", throwable.message)
+            }
+
+            Assert.assertTrue(result.isFailure)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun validatePassword_ConnectionError() {
+        val resultMock: Result<IngresseResponse<PasswordStrengthJSON>> =
+            Result.connectionError()
+
+        val repositoryMock = mock<PasswordStrength> {
+            onBlocking {
+                validateStrength(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.validateStrength(dispatcher, requestMock)
+
+            Assert.assertTrue(result.isConnectionError)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/repositories/PasswordTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/repositories/PasswordTest.kt
@@ -1,0 +1,274 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.ingresse.sdk.v2.models.base.IngresseResponse
+import com.ingresse.sdk.v2.models.request.RequestReset
+import com.ingresse.sdk.v2.models.request.UpdatePassword
+import com.ingresse.sdk.v2.models.request.ValidateHash
+import com.ingresse.sdk.v2.models.response.password.PasswordResetJSON
+import com.ingresse.sdk.v2.models.response.password.ValidateHashJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.model.onError
+import com.ingresse.sdk.v2.parses.model.onSuccess
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+
+@ExperimentalCoroutinesApi
+class PasswordTest {
+
+    @Mock
+    val dispatcher = TestCoroutineDispatcher()
+
+    @Mock
+    val requestResetMock = mock<RequestReset>()
+
+    @Mock
+    val validateHashMock = mock<ValidateHash>()
+
+    @Mock
+    val updatePasswordMock = mock<UpdatePassword>()
+
+    @Mock
+    val passwordResetJsonMock = mock<PasswordResetJSON> {
+        `when`(mock.status).thenReturn(true)
+        `when`(mock.message).thenReturn("message test")
+    }
+
+    @Mock
+    val validateHashJsonMock = mock<ValidateHashJSON> {
+        `when`(mock.isValid).thenReturn(true)
+    }
+
+    @Test
+    fun requestReset_SuccessTest() {
+        val ingresseResponseMock = mock<IngresseResponse<PasswordResetJSON>> {
+            `when`(mock.responseData).thenReturn(passwordResetJsonMock)
+        }
+
+        val resultMock = Result.success(ingresseResponseMock)
+
+        val repositoryMock = mock<Password> {
+            onBlocking {
+                requestReset(dispatcher, requestResetMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.requestReset(dispatcher, requestResetMock)
+            result.onSuccess {
+                val jsonResult = it.responseData
+
+                Assert.assertEquals("message test", jsonResult?.message)
+                Assert.assertTrue(jsonResult?.status == true)
+            }
+
+            Assert.assertTrue(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun requestReset_FailTest() {
+        val resultMock: Result<IngresseResponse<PasswordResetJSON>> =
+            Result.error(400, Throwable("Thrown an exception"))
+
+        val repositoryMock = mock<Password> {
+            onBlocking {
+                requestReset(dispatcher, requestResetMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.requestReset(dispatcher, requestResetMock)
+            result.onError { code, throwable ->
+                Assert.assertEquals(400, code)
+                Assert.assertEquals("Thrown an exception", throwable.message)
+            }
+
+            Assert.assertTrue(result.isFailure)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun requestReset_ConnectionErrorTest() {
+        val resultMock: Result<IngresseResponse<PasswordResetJSON>> =
+            Result.connectionError()
+
+        val repositoryMock = mock<Password> {
+            onBlocking {
+                requestReset(dispatcher, requestResetMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.requestReset(dispatcher, requestResetMock)
+
+            Assert.assertTrue(result.isConnectionError)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun validateHash_SuccessTest() {
+        val ingresseResponseMock = mock<IngresseResponse<ValidateHashJSON>> {
+            `when`(mock.responseData).thenReturn(validateHashJsonMock)
+        }
+
+        val resultMock = Result.success(ingresseResponseMock)
+
+        val repositoryMock = mock<Password> {
+            onBlocking {
+                validateHash(dispatcher, validateHashMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.validateHash(dispatcher, validateHashMock)
+            result.onSuccess {
+                val jsonResult = it.responseData
+
+                Assert.assertTrue(jsonResult?.isValid == true)
+            }
+
+            Assert.assertTrue(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun validateHash_FailTest() {
+        val resultMock: Result<IngresseResponse<ValidateHashJSON>> =
+            Result.error(400, Throwable("Thrown an exception"))
+
+        val repositoryMock = mock<Password> {
+            onBlocking {
+                validateHash(dispatcher, validateHashMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.validateHash(dispatcher, validateHashMock)
+            result.onError { code, throwable ->
+                Assert.assertEquals(400, code)
+                Assert.assertEquals("Thrown an exception", throwable.message)
+            }
+
+            Assert.assertTrue(result.isFailure)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun validateHash_ConnectionErrorTest() {
+        val resultMock: Result<IngresseResponse<ValidateHashJSON>> =
+            Result.connectionError()
+
+        val repositoryMock = mock<Password> {
+            onBlocking {
+                validateHash(dispatcher, validateHashMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.validateHash(dispatcher, validateHashMock)
+
+            Assert.assertTrue(result.isConnectionError)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun updatePassword_SuccessTest() {
+        val ingresseResponseMock = mock<IngresseResponse<PasswordResetJSON>> {
+            `when`(mock.responseData).thenReturn(passwordResetJsonMock)
+        }
+
+        val resultMock = Result.success(ingresseResponseMock)
+
+        val repositoryMock = mock<Password> {
+            onBlocking {
+                updatePassword(dispatcher, updatePasswordMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.updatePassword(dispatcher, updatePasswordMock)
+            result.onSuccess {
+                val jsonResult = it.responseData
+
+                Assert.assertEquals("message test", jsonResult?.message)
+                Assert.assertTrue(jsonResult?.status == true)
+            }
+
+            Assert.assertTrue(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun updatePassword_FailTest() {
+        val resultMock: Result<IngresseResponse<PasswordResetJSON>> =
+            Result.error(400, Throwable("Thrown an exception"))
+
+        val repositoryMock = mock<Password> {
+            onBlocking {
+                updatePassword(dispatcher, updatePasswordMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.updatePassword(dispatcher, updatePasswordMock)
+            result.onError { code, throwable ->
+                Assert.assertEquals(400, code)
+                Assert.assertEquals("Thrown an exception", throwable.message)
+            }
+
+            Assert.assertTrue(result.isFailure)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun updatePassword_ConnectionErrorTest() {
+        val resultMock: Result<IngresseResponse<PasswordResetJSON>> =
+            Result.connectionError()
+
+        val repositoryMock = mock<Password> {
+            onBlocking {
+                updatePassword(dispatcher, updatePasswordMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.updatePassword(dispatcher, updatePasswordMock)
+
+            Assert.assertTrue(result.isConnectionError)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/services/HomeServiceTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/services/HomeServiceTest.kt
@@ -1,0 +1,49 @@
+@file:Suppress("BlockingMethodInNonBlockingContext")
+
+package com.ingresse.sdk.v2.services
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert
+import org.junit.Test
+import retrofit2.Response
+
+@ExperimentalCoroutinesApi
+class HomeServiceTest {
+
+    @Test
+    fun getHomeCategories_SuccessTest() {
+        val serviceMock = mock<HomeService> {
+            onBlocking {
+                getHomeCategories()
+            } doReturn Response.success("Test body")
+        }
+
+        runBlockingTest {
+            val result = serviceMock.getHomeCategories()
+
+            Assert.assertTrue(result.isSuccessful)
+            Assert.assertEquals("Test body", result.body())
+        }
+    }
+
+    @Test
+    fun getHomeCategories_FailTest() {
+        val serviceMock = mock<HomeService> {
+            onBlocking {
+                getHomeCategories()
+            } doReturn Response.error(400, "Test body".toResponseBody())
+        }
+
+        runBlockingTest {
+            val result = serviceMock.getHomeCategories()
+
+            Assert.assertFalse(result.isSuccessful)
+            Assert.assertEquals(400, result.code())
+            Assert.assertEquals("Test body", result.errorBody()?.string())
+        }
+    }
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/services/PasswordServiceTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/services/PasswordServiceTest.kt
@@ -1,0 +1,177 @@
+package com.ingresse.sdk.v2.services
+
+import com.ingresse.sdk.v2.models.request.RequestReset
+import com.ingresse.sdk.v2.models.request.UpdatePassword
+import com.ingresse.sdk.v2.models.request.ValidateHash
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import retrofit2.Response
+
+@Suppress("BlockingMethodInNonBlockingContext")
+@ExperimentalCoroutinesApi
+class PasswordServiceTest {
+
+    private val apiKey = "ABC123456789"
+
+    @Mock
+    val requestResetMock = mock<RequestReset>()
+
+    @Mock
+    val validateHashMock = mock<ValidateHash>()
+
+    @Mock
+    val updatePasswordMock = mock<UpdatePassword>()
+
+    @Test
+    fun requestRecover_SuccessTest() {
+        val serviceMock = mock<PasswordService> {
+            onBlocking {
+                requestReset(
+                    apikey = apiKey,
+                    email = requestResetMock.email
+                )
+            } doReturn Response.success("Test body")
+        }
+
+        runBlockingTest {
+            val result = serviceMock.requestReset(
+                apikey = apiKey,
+                email = requestResetMock.email
+            )
+
+            Assert.assertTrue(result.isSuccessful)
+            Assert.assertEquals("Test body", result.body())
+        }
+    }
+
+    @Test
+    fun requestReset_FailTest() {
+        val serviceMock = mock<PasswordService> {
+            onBlocking {
+                requestReset(
+                    apikey = apiKey,
+                    email = requestResetMock.email
+                )
+            } doReturn Response.error(400, "Test body".toResponseBody())
+        }
+
+        runBlockingTest {
+            val result = serviceMock.requestReset(
+                apikey = apiKey,
+                email = requestResetMock.email
+            )
+
+            Assert.assertFalse(result.isSuccessful)
+            Assert.assertEquals(400, result.code())
+            Assert.assertEquals("Test body", result.errorBody()?.string())
+        }
+    }
+
+    @Test
+    fun validateHash_SuccessTest() {
+        val serviceMock = mock<PasswordService> {
+            onBlocking {
+                validateHash(
+                    apikey = apiKey,
+                    email = validateHashMock.email,
+                    hash = validateHashMock.hash
+                )
+            } doReturn Response.success("Test body")
+        }
+
+        runBlockingTest {
+            val result = serviceMock.validateHash(
+                apikey = apiKey,
+                email = validateHashMock.email,
+                hash = validateHashMock.hash
+            )
+
+            Assert.assertTrue(result.isSuccessful)
+            Assert.assertEquals("Test body", result.body())
+        }
+    }
+
+    @Test
+    fun validateHash_FailTest() {
+        val serviceMock = mock<PasswordService> {
+            onBlocking {
+                validateHash(
+                    apikey = apiKey,
+                    email = validateHashMock.email,
+                    hash = validateHashMock.hash
+                )
+            } doReturn Response.error(400, "Test body".toResponseBody())
+        }
+
+        runBlockingTest {
+            val result = serviceMock.validateHash(
+                apikey = apiKey,
+                email = validateHashMock.email,
+                hash = validateHashMock.hash
+            )
+
+            Assert.assertFalse(result.isSuccessful)
+            Assert.assertEquals(400, result.code())
+            Assert.assertEquals("Test body", result.errorBody()?.string())
+        }
+    }
+
+    @Test
+    fun updatePassword_SuccessTest() {
+        val serviceMock = mock<PasswordService> {
+            onBlocking {
+                updatePassword(
+                    apikey = apiKey,
+                    email = updatePasswordMock.email,
+                    password = updatePasswordMock.password,
+                    hash = updatePasswordMock.hash
+                )
+            } doReturn Response.success("Test body")
+        }
+
+        runBlockingTest {
+            val result = serviceMock.updatePassword(
+                apikey = apiKey,
+                email = updatePasswordMock.email,
+                password = updatePasswordMock.password,
+                hash = updatePasswordMock.hash
+            )
+
+            Assert.assertTrue(result.isSuccessful)
+            Assert.assertEquals("Test body", result.body())
+        }
+    }
+
+    @Test
+    fun updatePassword_FailTest() {
+        val serviceMock = mock<PasswordService> {
+            onBlocking {
+                updatePassword(
+                    apikey = apiKey,
+                    email = updatePasswordMock.email,
+                    password = updatePasswordMock.password,
+                    hash = updatePasswordMock.hash
+                )
+            } doReturn Response.error(400, "Test body".toResponseBody())
+        }
+
+        runBlockingTest {
+            val result = serviceMock.updatePassword(
+                apikey = apiKey,
+                email = updatePasswordMock.email,
+                password = updatePasswordMock.password,
+                hash = updatePasswordMock.hash
+            )
+
+            Assert.assertFalse(result.isSuccessful)
+            Assert.assertEquals(400, result.code())
+            Assert.assertEquals("Test body", result.errorBody()?.string())
+        }
+    }
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/services/PasswordStrengthServiceTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/services/PasswordStrengthServiceTest.kt
@@ -1,0 +1,68 @@
+package com.ingresse.sdk.v2.services
+
+import com.ingresse.sdk.v2.models.request.ValidateStrength
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import retrofit2.Response
+
+@Suppress("BlockingMethodInNonBlockingContext")
+@ExperimentalCoroutinesApi
+class PasswordStrengthServiceTest {
+
+    private val apiKey = "ABC123456789"
+
+    @Mock
+    val requestMock = mock<ValidateStrength>()
+
+    @Test
+    fun validateStrength_SuccessTest() {
+        val serviceMock = mock<PasswordStrengthService> {
+            onBlocking {
+                validatePasswordStrength(
+                    apikey = apiKey,
+                    password = requestMock.password
+                )
+            } doReturn Response.success("Test body")
+        }
+
+        runBlockingTest {
+            val result = serviceMock.validatePasswordStrength(
+                apikey = apiKey,
+                password = requestMock.password
+            )
+
+            Assert.assertTrue(result.isSuccessful)
+            Assert.assertEquals("Test body", result.body())
+        }
+    }
+
+    @Test
+    fun validateStrength_FailTest() {
+
+        val serviceMock = mock<PasswordStrengthService> {
+            onBlocking {
+                validatePasswordStrength(
+                    apikey = apiKey,
+                    password = requestMock.password
+                )
+            } doReturn Response.error(400, "Test body".toResponseBody())
+        }
+
+        runBlockingTest {
+            val result = serviceMock.validatePasswordStrength(
+                apikey = apiKey,
+                password = requestMock.password
+            )
+
+            Assert.assertFalse(result.isSuccessful)
+            Assert.assertEquals(400, result.code())
+            Assert.assertEquals("Test body", result.errorBody()?.string())
+        }
+    }
+}


### PR DESCRIPTION
## Contexto:
Depois da criação de um endpoint para acesso das categorias disponíveis para a home, agora será necessário implementar essa chamada no SDK Android para que a aplicação faça uso.

### Issue: https://ingresse.atlassian.net/browse/DEV-42

## O que foi feito:

- Adição da chamada da home que obtém as categorias de eventos;
```
curl --location --request GET 'https://<>.execute-api.us-east-1.amazonaws.com/home/'
```
- Criação de um objeto com URLs que fogem do padrão declarado na classe URLBuilder;
- Inclusão dos testes unitários.