### PR TITLE
[DEV-244][DEV-246] Infra: remoção do jCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,7 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
@@ -14,7 +12,8 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        maven { url "https://www.jitpack.io" }
+        mavenCentral()
     }
 }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -48,10 +48,5 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.9.0'
 
     // COROUTINES
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.2'
-}
-
-repositories {
-    mavenCentral()
-    maven { url 'https://jitpack.io' }
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3'
 }


### PR DESCRIPTION
## Contexto:
Enfrentamos alguns problemas recentes com o tempo de _build_ da aplicação. Junto com isso veio o aviso da atualização de serviço do [JCenter](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) e todos os problemas que encontrávamos nas sincronizações do _gradle_ tinham relação com bibliotecas antigas que estavam sendo distribuídas por lá. Com base nisso precisamos remover todas essas dependências e atualizar bibliotecas para o uso mais recente com _mavenCentral_.

### Google warning: https://developer.android.com/studio/build/jcenter-migration
### Issue: https://ingresse.atlassian.net/browse/DEV-244

#### O que foi feito:
- Remoção do JCenter;
- Atualização de biblioteca (coroutines-core);