### PR TITLE
Inclusão da chamada de lista de eventos do produtor

### DIFF
--- a/sdk/src/main/java/com/ingresse/sdk/IngresseService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/IngresseService.kt
@@ -25,6 +25,7 @@ import com.ingresse.sdk.services.UserService
 import com.ingresse.sdk.services.WebSocketService
 import com.ingresse.sdk.services.ZipCodeService
 import com.ingresse.sdk.v2.repositories.Auth
+import com.ingresse.sdk.v2.repositories.Event
 import com.ingresse.sdk.v2.repositories.EventDetails
 import com.ingresse.sdk.v2.repositories.Highlights
 import com.ingresse.sdk.v2.repositories.Home
@@ -62,6 +63,7 @@ class IngresseService(var client: IngresseClient) {
 
     var v2 = object : V2Services {
         override val auth = Auth(client)
+        override val event = Event(client)
         override val eventDetails = EventDetails(client)
         override val highlights = Highlights(client)
         override val home = Home(client)

--- a/sdk/src/main/java/com/ingresse/sdk/V2Services.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/V2Services.kt
@@ -1,6 +1,7 @@
 package com.ingresse.sdk
 
 import com.ingresse.sdk.v2.repositories.Auth
+import com.ingresse.sdk.v2.repositories.Event
 import com.ingresse.sdk.v2.repositories.EventDetails
 import com.ingresse.sdk.v2.repositories.Highlights
 import com.ingresse.sdk.v2.repositories.Home
@@ -12,6 +13,7 @@ import com.ingresse.sdk.v2.repositories.UserWallet
 
 interface V2Services {
     val auth: Auth
+    val event: Event
     val eventDetails: EventDetails
     val highlights: Highlights
     val home: Home

--- a/sdk/src/main/java/com/ingresse/sdk/services/EventService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/EventService.kt
@@ -77,6 +77,16 @@ class EventService(private val client: IngresseClient) {
      * @param onTokenExpired - token expired callback
      * @param onConnectionError - connection error callback
      */
+    @Deprecated(
+        message = "This call will no longer be maintained. Use V2 replacements.",
+        replaceWith = ReplaceWith(
+            expression = "Event(client).getProducerEventList(request = SearchEvents())",
+            imports = [
+                "com.ingresse.sdk.v2.repositories",
+                "com.ingresse.sdk.v2.models.request.SearchEvents",
+            ]
+        )
+    )
     fun getEventListByProducer(concurrent: Boolean = false,
                                request: EventListByProducer? = EventListByProducer(),
                                onSuccess: (Pair<ArrayList<Source<EventJSON>>, Int>) -> Unit,
@@ -143,6 +153,16 @@ class EventService(private val client: IngresseClient) {
      * @param onTokenExpired - token expired callback
      * @param onConnectionError - connection error callback
      */
+    @Deprecated(
+        message = "This call will no longer be maintained. Use V2 replacements.",
+        replaceWith = ReplaceWith(
+            expression = "Event(client).getProducerEventDetails(request = ProducerEventDetails())",
+            imports = [
+                "com.ingresse.sdk.v2.repositories",
+                "com.ingresse.sdk.v2.models.request.ProducerEventDetails",
+            ]
+        )
+    )
     fun getEventDescription(eventId: String,
                             onSuccess: (String) -> Unit,
                             onError: ErrorBlock,
@@ -191,6 +211,16 @@ class EventService(private val client: IngresseClient) {
      * @param onTokenExpired - token expired callback
      * @param onConnectionError - connection error callback
      */
+    @Deprecated(
+        message = "This call will no longer be maintained. Use V2 replacements.",
+        replaceWith = ReplaceWith(
+            expression = "Event(client).getProducerEventDetails(request = ProducerEventDetails())",
+            imports = [
+                "com.ingresse.sdk.v2.repositories",
+                "com.ingresse.sdk.v2.models.request.ProducerEventDetails",
+            ]
+        )
+    )
     fun getEventStaff(eventId: String,
                       onSuccess: (EventStaffJSON) -> Unit,
                       onError: ErrorBlock,

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/request/ProducerEventDetails.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/request/ProducerEventDetails.kt
@@ -1,0 +1,12 @@
+package com.ingresse.sdk.v2.models.request
+
+data class ProducerEventDetails(
+    val eventId: Int,
+    val fields: String?,
+) {
+
+    constructor(eventId: Int) : this(
+        eventId = eventId,
+        fields = null
+    )
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/request/SearchEvents.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/request/SearchEvents.kt
@@ -40,4 +40,27 @@ data class SearchEvents(
         orderBy = orderBy ?: SEARCH_QUERY_ORDER,
         offset = offset ?: 0
     )
+
+    constructor(
+        title: String? = null,
+        state: String? = null,
+        category: String? = null,
+        term: String? = null,
+        size: Int? = null,
+        from: String? = null,
+        to: String? = null,
+        orderBy: String? = null,
+        offset: Int? = null,
+    ) : this(
+        company = Company.INGRESSE,
+        title = title,
+        state = state,
+        category = category,
+        term = term,
+        size = size ?: PAGE_SIZE,
+        from = from ?: CURRENT_DATE_MINUS_SIX_HOURS,
+        to = to,
+        orderBy = orderBy ?: SEARCH_QUERY_ORDER,
+        offset = offset ?: 0
+    )
 }

--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/response/searchEvents/StaffJSON.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/response/searchEvents/StaffJSON.kt
@@ -1,5 +1,15 @@
 package com.ingresse.sdk.v2.models.response.searchEvents
 
+import com.google.gson.annotations.SerializedName
+
 data class StaffJSON(
     val admin: List<Int>?,
+    @SerializedName("entrance_manager")
+    val entranceManager: List<Int>?,
+    @SerializedName("entrance_operator")
+    val entranceOperator: List<Int>?,
+    @SerializedName("sales_manager")
+    val salesManager: List<Int>?,
+    @SerializedName("sales_operator")
+    val salesOperator: List<Int>?,
 )

--- a/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Event.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Event.kt
@@ -1,0 +1,73 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.google.gson.GsonBuilder
+import com.ingresse.sdk.IngresseClient
+import com.ingresse.sdk.builders.ClientBuilder
+import com.ingresse.sdk.builders.Host
+import com.ingresse.sdk.builders.URLBuilder
+import com.ingresse.sdk.v2.models.base.ResponseHits
+import com.ingresse.sdk.v2.models.request.ProducerEventDetails
+import com.ingresse.sdk.v2.models.request.SearchEvents
+import com.ingresse.sdk.v2.models.response.searchEvents.SearchEventsJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.resultParser
+import com.ingresse.sdk.v2.services.EventService
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class Event(client: IngresseClient) {
+    private val service: EventService
+
+    init {
+        val httpClient = ClientBuilder(client)
+            .addRequestHeaders()
+            .build()
+
+        val gsonBuilder = GsonBuilder().create()
+
+        val adapter = Retrofit.Builder()
+            .client(httpClient)
+            .addConverterFactory(GsonConverterFactory.create(gsonBuilder))
+            .baseUrl(URLBuilder(Host.SEARCH, client.environment).build())
+            .build()
+
+        service = adapter.create(EventService::class.java)
+    }
+
+    suspend fun getProducerEventListPlain(request: SearchEvents) =
+        service.getProducerEventList(
+            title = request.title,
+            state = request.state,
+            category = request.category,
+            term = request.term,
+            size = request.size,
+            from = request.from,
+            to = request.to,
+            orderBy = request.orderBy,
+            offset = request.offset
+        )
+
+    suspend fun getSearchedEvents(
+        dispatcher: CoroutineDispatcher = Dispatchers.Default,
+        request: SearchEvents,
+    ): Result<ResponseHits<SearchEventsJSON>> =
+        resultParser(dispatcher) {
+            getProducerEventListPlain(request)
+        }
+
+    suspend fun getProducerEventDetailsPlain(request: ProducerEventDetails) =
+        service.getProducerEventDetails(
+            eventId = request.eventId,
+            fields = request.fields
+        )
+
+    suspend fun getProducerEventDetails(
+        dispatcher: CoroutineDispatcher = Dispatchers.Default,
+        request: ProducerEventDetails,
+    ): Result<ResponseHits<SearchEventsJSON>> =
+        resultParser(dispatcher) {
+            getProducerEventDetailsPlain(request)
+        }
+}

--- a/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Event.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Event.kt
@@ -49,7 +49,7 @@ class Event(client: IngresseClient) {
             offset = request.offset
         )
 
-    suspend fun getSearchedEvents(
+    suspend fun getProducerEventList(
         dispatcher: CoroutineDispatcher = Dispatchers.Default,
         request: SearchEvents,
     ): Result<ResponseHits<SearchEventsJSON>> =

--- a/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Event.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/repositories/Event.kt
@@ -30,7 +30,7 @@ class Event(client: IngresseClient) {
         val adapter = Retrofit.Builder()
             .client(httpClient)
             .addConverterFactory(GsonConverterFactory.create(gsonBuilder))
-            .baseUrl(URLBuilder(Host.SEARCH, client.environment).build())
+            .baseUrl(URLBuilder(Host.EVENTS, client.environment).build())
             .build()
 
         service = adapter.create(EventService::class.java)

--- a/sdk/src/main/java/com/ingresse/sdk/v2/services/EventService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/services/EventService.kt
@@ -1,0 +1,46 @@
+package com.ingresse.sdk.v2.services
+
+import com.ingresse.sdk.v2.models.base.ResponseHits
+import com.ingresse.sdk.v2.models.response.searchEvents.SearchEventsJSON
+import retrofit2.http.GET
+import retrofit2.http.Path
+import retrofit2.http.Query
+
+interface EventService {
+
+    /**
+     * Get producer´s event list
+     *
+     * @param title - Event's title to filter
+     * @param size - Size of total results in page
+     * @param orderBy - Order results
+     * @param from - Get from specific date or moment
+     * @param to - Get to specific date or moment
+     * @param offset - Get from specific page
+     */
+    @Suppress("LongParameterList")
+    @GET("/search/producer")
+    suspend fun getProducerEventList(
+        @Query("title") title: String?,
+        @Query("state") state: String?,
+        @Query("category") category: String?,
+        @Query("term") term: String?,
+        @Query("size") size: Int?,
+        @Query("from") from: String?,
+        @Query("to") to: String?,
+        @Query("orderBy") orderBy: String?,
+        @Query("offset") offset: Int,
+    ): ResponseHits<SearchEventsJSON>
+
+    /**
+     * Get event details
+     *
+     * @param eventId - Id from event
+     * @param fields - Get specifically described fields
+     */
+    @GET("/{eventId}")
+    suspend fun getProducerEventDetails(
+        @Path("eventId") eventId: Int,
+        @Query("fields") fields: String?,
+    ): ResponseHits<SearchEventsJSON>
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/repositories/EventTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/repositories/EventTest.kt
@@ -1,0 +1,245 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.ingresse.sdk.v2.models.base.Data
+import com.ingresse.sdk.v2.models.base.ResponseHits
+import com.ingresse.sdk.v2.models.base.Source
+import com.ingresse.sdk.v2.models.request.ProducerEventDetails
+import com.ingresse.sdk.v2.models.request.SearchEvents
+import com.ingresse.sdk.v2.models.response.searchEvents.SearchEventsJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.model.onError
+import com.ingresse.sdk.v2.parses.model.onSuccess
+import com.ingresse.sdk.v2.parses.model.onTokenExpired
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+
+@ExperimentalCoroutinesApi
+class EventTest {
+
+    @Mock
+    val dispatcher = TestCoroutineDispatcher()
+
+    @Mock
+    val searchRequestMock = mock<SearchEvents>()
+
+    @Mock
+    val detailsRequestMock = mock<ProducerEventDetails>()
+
+    @Mock
+    val jsonMock = mock<SearchEventsJSON> {
+        Mockito.`when`(mock.id).thenReturn(123456)
+        Mockito.`when`(mock.title).thenReturn("test title")
+    }
+
+    @Mock
+    val dataMock = mock<Data<SearchEventsJSON>> {
+        Mockito.`when`(mock.hits).thenReturn(listOf(Source(jsonMock)))
+        Mockito.`when`(mock.total).thenReturn(1)
+    }
+
+    @Mock
+    val responseMock = mock<ResponseHits<SearchEventsJSON>> {
+        Mockito.`when`(mock.data).thenReturn(dataMock)
+    }
+
+    @Test
+    fun getProducerEventList_SuccessTest() {
+        val resultMock = Result.success(responseMock)
+
+        val repositoryMock = mock<Event> {
+            onBlocking {
+                getProducerEventList(dispatcher, searchRequestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getProducerEventList(dispatcher, searchRequestMock)
+            result.onSuccess {
+                val jsonResult = it.data?.hits?.first()?.source
+
+                Assert.assertEquals(1, it.data?.total)
+                Assert.assertEquals("test title", jsonResult?.title)
+                Assert.assertEquals(123456, jsonResult?.id)
+            }
+
+            Assert.assertTrue(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getProducerEventList_FailTest() {
+        val resultMock: Result<ResponseHits<SearchEventsJSON>> =
+            Result.error(400, Throwable("Thrown an exception"))
+
+        val repositoryMock = mock<Event> {
+            onBlocking {
+                getProducerEventList(dispatcher, searchRequestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getProducerEventList(dispatcher, searchRequestMock)
+            result.onError { code, throwable ->
+                Assert.assertEquals(400, code)
+                Assert.assertEquals("Thrown an exception", throwable.message)
+            }
+
+            Assert.assertTrue(result.isFailure)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getProducerEventList_ConnectionErrorTest() {
+        val resultMock: Result<ResponseHits<SearchEventsJSON>> =
+            Result.connectionError()
+
+        val repositoryMock = mock<Event> {
+            onBlocking {
+                getProducerEventList(dispatcher, searchRequestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getProducerEventList(dispatcher, searchRequestMock)
+
+            Assert.assertTrue(result.isConnectionError)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getProducerEventList_TokenExpiredTest() {
+        val resultMock: Result<ResponseHits<SearchEventsJSON>> =
+            Result.tokenExpired(1234)
+
+        val repositoryMock = mock<Event> {
+            onBlocking {
+                getProducerEventList(dispatcher, searchRequestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getProducerEventList(dispatcher, searchRequestMock)
+            result.onTokenExpired { code ->
+                Assert.assertEquals(1234, code)
+            }
+
+            Assert.assertTrue(result.isTokenExpired)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+        }
+    }
+
+    @Test
+    fun getProducerEventDetails_SuccessTest() {
+        val resultMock = Result.success(responseMock)
+
+        val repositoryMock = mock<Event> {
+            onBlocking {
+                getProducerEventDetails(dispatcher, detailsRequestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getProducerEventDetails(dispatcher, detailsRequestMock)
+            result.onSuccess {
+                val jsonResult = it.data?.hits?.first()?.source
+
+                Assert.assertEquals(1, it.data?.total)
+                Assert.assertEquals("test title", jsonResult?.title)
+                Assert.assertEquals(123456, jsonResult?.id)
+            }
+
+            Assert.assertTrue(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getProducerEventDetails_FailTest() {
+        val resultMock: Result<ResponseHits<SearchEventsJSON>> =
+            Result.error(400, Throwable("Thrown an exception"))
+
+        val repositoryMock = mock<Event> {
+            onBlocking {
+                getProducerEventDetails(dispatcher, detailsRequestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getProducerEventDetails(dispatcher, detailsRequestMock)
+            result.onError { code, throwable ->
+                Assert.assertEquals(400, code)
+                Assert.assertEquals("Thrown an exception", throwable.message)
+            }
+
+            Assert.assertTrue(result.isFailure)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getProducerEventDetails_ConnectionErrorTest() {
+        val resultMock: Result<ResponseHits<SearchEventsJSON>> =
+            Result.connectionError()
+
+        val repositoryMock = mock<Event> {
+            onBlocking {
+                getProducerEventDetails(dispatcher, detailsRequestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getProducerEventDetails(dispatcher, detailsRequestMock)
+
+            Assert.assertTrue(result.isConnectionError)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getProducerEventDetails_TokenExpiredTest() {
+        val resultMock: Result<ResponseHits<SearchEventsJSON>> =
+            Result.tokenExpired(1234)
+
+        val repositoryMock = mock<Event> {
+            onBlocking {
+                getProducerEventDetails(dispatcher, detailsRequestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getProducerEventDetails(dispatcher, detailsRequestMock)
+            result.onTokenExpired { code ->
+                Assert.assertEquals(1234, code)
+            }
+
+            Assert.assertTrue(result.isTokenExpired)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+        }
+    }
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/services/EventServiceTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/services/EventServiceTest.kt
@@ -1,0 +1,195 @@
+package com.ingresse.sdk.v2.services
+
+import com.ingresse.sdk.v2.models.base.Data
+import com.ingresse.sdk.v2.models.base.ResponseHits
+import com.ingresse.sdk.v2.models.base.Source
+import com.ingresse.sdk.v2.models.request.ProducerEventDetails
+import com.ingresse.sdk.v2.models.request.SearchEvents
+import com.ingresse.sdk.v2.models.response.searchEvents.SearchEventsJSON
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+
+@ExperimentalCoroutinesApi
+class EventServiceTest {
+
+    @Mock
+    val searchRequestMock = mock<SearchEvents>()
+
+    @Mock
+    val detailsRequestMock = mock<ProducerEventDetails>()
+
+    @Test
+    fun getProducerEventList_SuccessTest() {
+        val jsonMock = mock<SearchEventsJSON> {
+            Mockito.`when`(mock.id).thenReturn(123456)
+            Mockito.`when`(mock.title).thenReturn("test title")
+        }
+
+        val dataMock = mock<Data<SearchEventsJSON>> {
+            Mockito.`when`(mock.hits).thenReturn(listOf(Source(jsonMock)))
+            Mockito.`when`(mock.total).thenReturn(1)
+        }
+
+        val responseMock = mock<ResponseHits<SearchEventsJSON>> {
+            Mockito.`when`(mock.data).thenReturn(dataMock)
+        }
+
+        val serviceMock = mock<EventService> {
+            onBlocking {
+                getProducerEventList(
+                    title = searchRequestMock.title,
+                    state = searchRequestMock.state,
+                    category = searchRequestMock.category,
+                    term = searchRequestMock.term,
+                    size = searchRequestMock.size,
+                    from = searchRequestMock.from,
+                    to = searchRequestMock.to,
+                    orderBy = searchRequestMock.orderBy,
+                    offset = searchRequestMock.offset
+                )
+            } doReturn responseMock
+        }
+
+        runBlockingTest {
+            val result = kotlin.runCatching {
+                serviceMock.getProducerEventList(
+                    title = searchRequestMock.title,
+                    state = searchRequestMock.state,
+                    category = searchRequestMock.category,
+                    term = searchRequestMock.term,
+                    size = searchRequestMock.size,
+                    from = searchRequestMock.from,
+                    to = searchRequestMock.to,
+                    orderBy = searchRequestMock.orderBy,
+                    offset = searchRequestMock.offset
+                )
+            }.onSuccess {
+                val jsonResult = it.data?.hits?.first()?.source
+
+                Assert.assertEquals(1, it.data?.total)
+                Assert.assertEquals("test title", jsonResult?.title)
+                Assert.assertEquals(123456, jsonResult?.id)
+            }
+
+            Assert.assertFalse(result.isFailure)
+            Assert.assertTrue(result.isSuccess)
+        }
+    }
+
+    @Test
+    fun getProducerEventList_FailTest() {
+        val serviceMock = mock<EventService> {
+            onBlocking {
+                getProducerEventList(
+                    title = searchRequestMock.title,
+                    state = searchRequestMock.state,
+                    category = searchRequestMock.category,
+                    term = searchRequestMock.term,
+                    size = searchRequestMock.size,
+                    from = searchRequestMock.from,
+                    to = searchRequestMock.to,
+                    orderBy = searchRequestMock.orderBy,
+                    offset = searchRequestMock.offset
+                )
+            } doThrow RuntimeException("Thrown an exception")
+        }
+
+        runBlockingTest {
+            val result = kotlin.runCatching {
+                serviceMock.getProducerEventList(
+                    title = searchRequestMock.title,
+                    state = searchRequestMock.state,
+                    category = searchRequestMock.category,
+                    term = searchRequestMock.term,
+                    size = searchRequestMock.size,
+                    from = searchRequestMock.from,
+                    to = searchRequestMock.to,
+                    orderBy = searchRequestMock.orderBy,
+                    offset = searchRequestMock.offset
+                )
+            }.onFailure {
+                Assert.assertEquals("Thrown an exception", it.message)
+            }
+
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertTrue(result.isFailure)
+        }
+    }
+
+    @Test
+    fun getProducerEventDetails_SuccessTest() {
+        val jsonMock = mock<SearchEventsJSON> {
+            Mockito.`when`(mock.id).thenReturn(123456)
+            Mockito.`when`(mock.title).thenReturn("test title")
+        }
+
+        val dataMock = mock<Data<SearchEventsJSON>> {
+            Mockito.`when`(mock.hits).thenReturn(listOf(Source(jsonMock)))
+            Mockito.`when`(mock.total).thenReturn(1)
+        }
+
+        val responseMock = mock<ResponseHits<SearchEventsJSON>> {
+            Mockito.`when`(mock.data).thenReturn(dataMock)
+        }
+
+        val serviceMock = mock<EventService> {
+            onBlocking {
+                getProducerEventDetails(
+                    eventId = detailsRequestMock.eventId,
+                    fields = detailsRequestMock.fields
+                )
+            } doReturn responseMock
+        }
+
+        runBlockingTest {
+            val result = kotlin.runCatching {
+                serviceMock.getProducerEventDetails(
+                    eventId = detailsRequestMock.eventId,
+                    fields = detailsRequestMock.fields
+                )
+            }.onSuccess {
+                val jsonResult = it.data?.hits?.first()?.source
+
+                Assert.assertEquals(1, it.data?.total)
+                Assert.assertEquals("test title", jsonResult?.title)
+                Assert.assertEquals(123456, jsonResult?.id)
+            }
+
+            Assert.assertFalse(result.isFailure)
+            Assert.assertTrue(result.isSuccess)
+        }
+    }
+
+    @Test
+    fun getProducerEventDetails_FailTest() {
+        val serviceMock = mock<EventService> {
+            onBlocking {
+                getProducerEventDetails(
+                    eventId = detailsRequestMock.eventId,
+                    fields = detailsRequestMock.fields
+                )
+            } doThrow RuntimeException("Thrown an exception")
+        }
+
+        runBlockingTest {
+            val result = kotlin.runCatching {
+                serviceMock.getProducerEventDetails(
+                    eventId = detailsRequestMock.eventId,
+                    fields = detailsRequestMock.fields
+                )
+            }.onFailure {
+                Assert.assertEquals("Thrown an exception", it.message)
+            }
+
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertTrue(result.isFailure)
+        }
+    }
+}


### PR DESCRIPTION
## Contexto: 
Estamos adicionando todas as chamadas existentes no SDK para a V2, e para isso, adicionamos as chamadas existentes no cenário de eventos, adicionando assim o método _get_ para lista de eventos e detalhes de um evento.

### O que foi feito:
- Adição da chamada _getProducerEventList_;
- Adição da chamada _getProducerEventList_ (método sem parser da Ingresse);
- Adição da chamada _getProducerEventDetails_;
- Adição da chamada _getProducerEventDetails_ (método sem parser da Ingresse);
- Adição dos testes unitários.