### PR TITLE
Inclusão dos testes unitários

### DIFF
--- a/sdk/src/test/java/com/ingresse/sdk/v2/repositories/CheckinReportThresholdTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/repositories/CheckinReportThresholdTest.kt
@@ -1,0 +1,102 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.ingresse.sdk.v2.models.request.CheckinThreshold
+import com.ingresse.sdk.v2.models.response.ThresholdJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.model.onError
+import com.ingresse.sdk.v2.parses.model.onSuccess
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+
+@ExperimentalCoroutinesApi
+class CheckinReportThresholdTest {
+
+    @Mock
+    val dispatcher = TestCoroutineDispatcher()
+
+    @Mock
+    val requestMock = mock<CheckinThreshold>()
+
+    @Mock
+    val thresholdJsonMock = mock<ThresholdJSON> {
+        `when`(mock.threshold).thenReturn(123)
+    }
+
+    @Test
+    fun getThreshold_SuccessTest() {
+        val resultMock = Result.success(thresholdJsonMock)
+
+        val repositoryMock = mock<CheckinReportThreshold> {
+            onBlocking {
+                getThreshold(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getThreshold(dispatcher, requestMock)
+            result.onSuccess {
+                val response = it.threshold
+
+                Assert.assertEquals(123, response)
+            }
+
+            Assert.assertTrue(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getThreshold_FailTest() {
+        val resultMock: Result<ThresholdJSON> =
+            Result.error(400, Throwable("Thrown an exception"))
+
+        val repositoryMock = mock<CheckinReportThreshold> {
+            onBlocking {
+                getThreshold(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getThreshold(dispatcher, requestMock)
+            result.onError { code, throwable ->
+                Assert.assertEquals(400, code)
+                Assert.assertEquals("Thrown an exception", throwable.message)
+            }
+
+            Assert.assertTrue(result.isFailure)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getThreshold_ConnectionErrorTest() {
+        val resultMock: Result<ThresholdJSON> =
+            Result.connectionError()
+
+        val repositoryMock = mock<CheckinReportThreshold> {
+            onBlocking {
+                getThreshold(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getThreshold(dispatcher, requestMock)
+
+            Assert.assertTrue(result.isConnectionError)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/repositories/TicketTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/repositories/TicketTest.kt
@@ -1,0 +1,132 @@
+package com.ingresse.sdk.v2.repositories
+
+import com.ingresse.sdk.v2.models.base.IngresseResponse
+import com.ingresse.sdk.v2.models.request.EventTickets
+import com.ingresse.sdk.v2.models.response.EventTicketJSON
+import com.ingresse.sdk.v2.parses.model.Result
+import com.ingresse.sdk.v2.parses.model.onError
+import com.ingresse.sdk.v2.parses.model.onSuccess
+import com.ingresse.sdk.v2.parses.model.onTokenExpired
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito.`when`
+
+@ExperimentalCoroutinesApi
+class TicketTest {
+
+    val dispatcher = TestCoroutineDispatcher()
+
+    @Mock
+    val requestMock = mock<EventTickets>()
+
+    @Mock
+    val eventTicketMock = mock<EventTicketJSON> {
+        `when`(mock.id).thenReturn(654321)
+    }
+
+    @Mock
+    val responseMock = mock<IngresseResponse<List<EventTicketJSON>>> {
+        `when`(mock.responseData).thenReturn(listOf(eventTicketMock))
+    }
+
+    @Test
+    fun getEventTickets_SuccessTest() {
+        val resultMock = Result.success(responseMock)
+
+        val repositoryMock = mock<Ticket> {
+            onBlocking {
+                getEventTickets(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getEventTickets(dispatcher, requestMock)
+            result.onSuccess {
+                val id = it.responseData?.first()?.id
+
+                Assert.assertEquals(654321, id)
+            }
+
+            Assert.assertTrue(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getEventTickets_FailTest() {
+        val resultMock: Result<IngresseResponse<List<EventTicketJSON>>> =
+            Result.error(400, Throwable("Thrown an exception"))
+
+        val repositoryMock = mock<Ticket> {
+            onBlocking {
+                getEventTickets(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getEventTickets(dispatcher, requestMock)
+            result.onError { code, throwable ->
+                Assert.assertEquals(400, code)
+                Assert.assertEquals("Thrown an exception", throwable.message)
+            }
+
+            Assert.assertTrue(result.isFailure)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isConnectionError)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getEventTickets_ConnectionError() {
+        val resultMock: Result<IngresseResponse<List<EventTicketJSON>>> =
+            Result.connectionError()
+
+        val repositoryMock = mock<Ticket> {
+            onBlocking {
+                getEventTickets(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getEventTickets(dispatcher, requestMock)
+
+            Assert.assertTrue(result.isConnectionError)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isTokenExpired)
+        }
+    }
+
+    @Test
+    fun getEventTickets_TokenExpiredTest() {
+        val resultMock: Result<IngresseResponse<List<EventTicketJSON>>> =
+            Result.tokenExpired(123)
+
+        val repositoryMock = mock<Ticket> {
+            onBlocking {
+                getEventTickets(dispatcher, requestMock)
+            } doReturn resultMock
+        }
+
+        runBlockingTest {
+            val result = repositoryMock.getEventTickets(dispatcher, requestMock)
+            result.onTokenExpired {
+                Assert.assertEquals(123, it)
+            }
+
+            Assert.assertTrue(result.isTokenExpired)
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertFalse(result.isFailure)
+            Assert.assertFalse(result.isConnectionError)
+        }
+    }
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/services/CheckinReportThresholdServiceTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/services/CheckinReportThresholdServiceTest.kt
@@ -1,0 +1,65 @@
+package com.ingresse.sdk.v2.services
+
+import com.ingresse.sdk.v2.models.request.CheckinThreshold
+import com.ingresse.sdk.v2.models.response.ThresholdJSON
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.Mockito
+
+@Suppress("BlockingMethodInNonBlockingContext")
+@ExperimentalCoroutinesApi
+class CheckinReportThresholdServiceTest {
+
+    @Mock
+    val requestMock = mock<CheckinThreshold>()
+
+    @Mock
+    val thresholdJsonMock = mock<ThresholdJSON> {
+        Mockito.`when`(mock.threshold).thenReturn(123)
+    }
+
+    @Test
+    fun getThreshold_SuccessTest() {
+        val serviceMock = mock<CheckinReportThresholdService> {
+            onBlocking {
+                getEntranceReportThreshold(requestMock.eventId)
+            } doReturn thresholdJsonMock
+        }
+
+        runBlockingTest {
+            val result = serviceMock.getEntranceReportThreshold(
+                eventId = requestMock.eventId
+            )
+
+            Assert.assertEquals(123, result.threshold)
+        }
+    }
+
+    @Test
+    fun getThreshold_FailTest() {
+        val serviceMock = mock<CheckinReportThresholdService> {
+            onBlocking {
+                getEntranceReportThreshold(requestMock.eventId)
+            } doThrow RuntimeException("Thrown an exception")
+        }
+
+        runBlockingTest {
+            val result = kotlin.runCatching {
+                serviceMock.getEntranceReportThreshold(
+                    eventId = requestMock.eventId
+                )
+            }.onFailure {
+                Assert.assertEquals("Thrown an exception", it.message)
+            }
+
+            Assert.assertFalse(result.isSuccess)
+            Assert.assertTrue(result.isFailure)
+        }
+    }
+}

--- a/sdk/src/test/java/com/ingresse/sdk/v2/services/HighlightsServiceTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/services/HighlightsServiceTest.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.test.runBlockingTest
 import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert
 import org.junit.Test
+import org.junit.runner.RunWith
 import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
 import retrofit2.Response
 
 @Suppress("BlockingMethodInNonBlockingContext")

--- a/sdk/src/test/java/com/ingresse/sdk/v2/services/TicketServiceTest.kt
+++ b/sdk/src/test/java/com/ingresse/sdk/v2/services/TicketServiceTest.kt
@@ -1,0 +1,71 @@
+package com.ingresse.sdk.v2.services
+
+import com.ingresse.sdk.v2.models.request.EventTickets
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mock
+import retrofit2.Response
+
+@Suppress("BlockingMethodInNonBlockingContext")
+@ExperimentalCoroutinesApi
+class TicketServiceTest {
+
+    private val apiKey = "ABC123456789"
+
+    @Mock
+    val requestMock = mock<EventTickets>()
+
+    @Test
+    fun getEventTickets_SuccessTest() {
+        val serviceMock = mock<TicketService> {
+            onBlocking {
+                getEventTickets(
+                    eventId = requestMock.eventId,
+                    sessionId = requestMock.sessionId,
+                    apikey = apiKey
+                )
+            } doReturn Response.success("Test body")
+        }
+
+        runBlockingTest {
+            val result = serviceMock.getEventTickets(
+                eventId = requestMock.eventId,
+                sessionId = requestMock.sessionId,
+                apikey = apiKey
+            )
+
+            Assert.assertTrue(result.isSuccessful)
+            Assert.assertEquals("Test body", result.body())
+        }
+    }
+
+    @Test
+    fun getEventTickets_FailTest() {
+        val serviceMock = mock<TicketService> {
+            onBlocking {
+                getEventTickets(
+                    eventId = requestMock.eventId,
+                    sessionId = requestMock.sessionId,
+                    apikey = apiKey
+                )
+            } doReturn Response.error(400, "Test body".toResponseBody())
+        }
+
+        runBlockingTest {
+            val result = serviceMock.getEventTickets(
+                eventId = requestMock.eventId,
+                sessionId = requestMock.sessionId,
+                apikey = apiKey
+            )
+
+            Assert.assertFalse(result.isSuccessful)
+            Assert.assertEquals(400, result.code())
+            Assert.assertEquals("Test body", result.errorBody()?.string())
+        }
+    }
+}


### PR DESCRIPTION
## Contexto:
Adição dos testes das últimas chamadas adicionas. 

### Referência:
#172 
#171 
#170 

### O que foi feito:
- Testes unitários dos serviços de tickets e checkinThreshold;
- Testes unitários dos repositórios de tickets e checkinThreshold;
- Testes unitários das chamadas de atualização dos atributos do evento.