### PR TITLE
[Bugfix] Relatório de vendas não aparece valor correto

### DIFF
--- a/sdk/src/main/java/com/ingresse/sdk/model/response/SessionDashboardJSON.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/model/response/SessionDashboardJSON.kt
@@ -19,7 +19,7 @@ data class SalesSummaryJSON(
     val totalPaymentCost: Float? = 0.0f,
     val totalSales: Float? = 0.0f,
     val totalPendingTickets: Int? = 0,
-    val partialRevenue: Int? = 0
+    val partialRevenue: Float? = 0.0f
 )
 
 data class SalesTicketTypeJSON(


### PR DESCRIPTION
- Quando o campo `partialRevenue` do objeto `SessionDashboardJSON` vem com centavos, o sdk não consegue fazer a conversão de int pra float e ocorre um erro no parseamento.