### PR TITLE
[Feature] Adiciona timeout no serviço de lista de ingressos

### DIFF
--- a/sdk/src/main/java/com/ingresse/sdk/services/TicketListService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/TicketListService.kt
@@ -5,6 +5,7 @@ import com.ingresse.sdk.IngresseClient
 import com.ingresse.sdk.base.IngresseCallback
 import com.ingresse.sdk.base.Response
 import com.ingresse.sdk.base.RetrofitCallback
+import com.ingresse.sdk.builders.ClientBuilder.Companion.TIMEOUT_DEFAULT
 import com.ingresse.sdk.builders.Host
 import com.ingresse.sdk.builders.URLBuilder
 import com.ingresse.sdk.errors.APIError
@@ -15,6 +16,7 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Call
 import retrofit2.Retrofit
 import retrofit2.converter.scalars.ScalarsConverterFactory
+import java.util.concurrent.TimeUnit
 import com.ingresse.sdk.model.request.Sale as Requests
 import com.ingresse.sdk.model.response.Sale as Responses
 import com.ingresse.sdk.request.Sale as Service
@@ -31,6 +33,10 @@ class TicketListService(private val client: IngresseClient) {
                 .baseUrl(URLBuilder(host, client.environment).build())
 
         val clientBuilder = OkHttpClient.Builder()
+
+        clientBuilder.callTimeout(TIMEOUT_DEFAULT, TimeUnit.SECONDS)
+        clientBuilder.readTimeout(TIMEOUT_DEFAULT, TimeUnit.SECONDS)
+        clientBuilder.connectTimeout(TIMEOUT_DEFAULT, TimeUnit.SECONDS)
 
         if (client.debug) {
             val logging = HttpLoggingInterceptor()


### PR DESCRIPTION
## Contexto
A chamada de tickets, em eventos com muitas sessões, estava passando de 10 segundos no tempo de resposta e exibindo a mensagem de sessões esgotadas. Para evitar a mensagem padrão, aumentamos o temo de timeout para 60 segundos, suficiente para conexões instáveis atingirem com sucesso a resposta.

### O que foi feito:
- Adiciona timeout de 60 segundos na TicketListService (backstage only)