### PR TITLE
[Feature] Adição dos atributos de passaporte do evento

### DIFF
--- a/sdk/src/main/java/com/ingresse/sdk/v2/models/response/searchEvents/AttributesJSON.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/v2/models/response/searchEvents/AttributesJSON.kt
@@ -4,13 +4,22 @@ data class AttributesJSON(
     private val liveEnabled: BooleanValueJSON?,
     private val validationCpfTicketbooth : BooleanValueJSON?,
     private val validationCpfTicketmodal : BooleanValueJSON?,
+    private val passportAtBottom: BooleanValueJSON?,
+    private val passportLabel: StringValueJSON?,
 ) {
     data class BooleanValueJSON(
         val name: String?,
         val value: Boolean?
     )
 
+    data class StringValueJSON(
+        val name: String?,
+        val value: String?
+    )
+
     fun liveEnabled() = liveEnabled?.value
     fun validationCpfTicketbooth() = validationCpfTicketbooth?.value
     fun validationCpfTicketModal() = validationCpfTicketmodal?.value
+    fun passportAtBottom() = passportAtBottom?.value
+    fun passportLabel() = passportLabel?.value
 }


### PR DESCRIPTION
## Objetivo
Adicionar os campos relativos a passaporte para consumo nos aplicativos

### O que foi feito:
- Adição do campo `passportAtBottom`;
- Adição do campo `passportLabel`.