### PR TITLE
[MOB-20] Adição de logger de erro

### DIFF
--- a/sdk/src/main/java/com/ingresse/sdk/IngresseClient.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/IngresseClient.kt
@@ -1,10 +1,16 @@
 package com.ingresse.sdk
 
+import com.ingresse.sdk.base.ErrorLogger
 import com.ingresse.sdk.builders.Environment
+import okhttp3.EventListener
+import okhttp3.Interceptor
 
-class IngresseClient(val key: String,
-                     val authToken: String,
-                     val userAgent: String,
-                     val environment: Environment,
-                     val customPrefix: String?,
-                     val debug: Boolean = false)
+class IngresseClient(
+    val key: String,
+    val authToken: String,
+    val userAgent: String,
+    val environment: Environment,
+    val customPrefix: String?,
+    val debug: Boolean = false,
+    val logger: ErrorLogger? = null,
+)

--- a/sdk/src/main/java/com/ingresse/sdk/base/Error.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/base/Error.kt
@@ -3,5 +3,4 @@ package com.ingresse.sdk.base
 class Error {
     var responseData: String = ""
     var responseError = ErrorData()
-    var responseStatus: Int = 0
 }

--- a/sdk/src/main/java/com/ingresse/sdk/base/ErrorLogger.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/base/ErrorLogger.kt
@@ -5,6 +5,7 @@ import java.net.URL
 abstract class ErrorLogger {
     abstract fun logError(
         url: URL,
+        requestData: String?,
         errorBody: String?,
         errorCode: Int?,
     )

--- a/sdk/src/main/java/com/ingresse/sdk/base/ErrorLogger.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/base/ErrorLogger.kt
@@ -1,0 +1,11 @@
+package com.ingresse.sdk.base
+
+import java.net.URL
+
+abstract class ErrorLogger {
+    abstract fun logError(
+        url: URL,
+        errorBody: String?,
+        errorCode: Int?,
+    )
+}

--- a/sdk/src/main/java/com/ingresse/sdk/services/AttributesService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/AttributesService.kt
@@ -98,7 +98,7 @@ class AttributesService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<DataArray<EventAttributesJSON>>() {}.type
-        mGetEventAttributesCall?.enqueue(RetrofitCallback(type, callback))
+        mGetEventAttributesCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -130,7 +130,7 @@ class AttributesService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Ignored>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -183,6 +183,6 @@ class AttributesService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<EventAttributesDataJSON>>() {}.type
-        mGetEventAttributesCall?.enqueue(RetrofitCallback(type, callback))
+        mGetEventAttributesCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/AuthService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/AuthService.kt
@@ -120,7 +120,7 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object: TypeToken<Response<CompanyLoginJSON>>() {}.type
-        mCompanyLoginCall?.enqueue(RetrofitCallback(type, callback, client.logger))
+        mCompanyLoginCall?.enqueue(RetrofitCallback(type, callback, null))
     }
 
     /**
@@ -171,7 +171,7 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object: TypeToken<Response<LoginJSON>>() {}.type
-        mLoginCall?.enqueue(RetrofitCallback(type, callback, client.logger))
+        mLoginCall?.enqueue(RetrofitCallback(type, callback, null))
     }
 
     /**
@@ -416,6 +416,6 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<AuthPasswordJSON>?>() {}.type
-        mUpdatePasswordCall?.enqueue(RetrofitCallback(type, callback, client.logger))
+        mUpdatePasswordCall?.enqueue(RetrofitCallback(type, callback, null))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/AuthService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/AuthService.kt
@@ -120,7 +120,7 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object: TypeToken<Response<CompanyLoginJSON>>() {}.type
-        mCompanyLoginCall?.enqueue(RetrofitCallback(type, callback))
+        mCompanyLoginCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -171,7 +171,7 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object: TypeToken<Response<LoginJSON>>() {}.type
-        mLoginCall?.enqueue(RetrofitCallback(type, callback))
+        mLoginCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -225,7 +225,7 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<LoginJSON>?>() {}.type
-        mLoginWithFacebook?.enqueue(RetrofitCallback(type, callback))
+        mLoginWithFacebook?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -269,7 +269,7 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object: TypeToken<Response<UserAuthTokenJSON>>() {}.type
-        mRenewAuthTokenCall?.enqueue(RetrofitCallback(type, callback))
+        mRenewAuthTokenCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -317,7 +317,7 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<AuthPasswordJSON>?>() {}.type
-        mRecoverPasswordCall?.enqueue(RetrofitCallback(type, callback))
+        mRecoverPasswordCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -366,7 +366,7 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<ValidateHashJSON>?>() {}.type
-        mValidateHashCall?.enqueue(RetrofitCallback(type, callback))
+        mValidateHashCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -416,6 +416,6 @@ class AuthService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<AuthPasswordJSON>?>() {}.type
-        mUpdatePasswordCall?.enqueue(RetrofitCallback(type, callback))
+        mUpdatePasswordCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/BalanceService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/BalanceService.kt
@@ -73,6 +73,6 @@ class BalanceService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponseType>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/EntranceReportService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/EntranceReportService.kt
@@ -83,6 +83,6 @@ class EntranceReportService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponseEntranceReport?>() {}.type
-        mGetEntranceReportService?.enqueue(RetrofitCallback(type, callback))
+        mGetEntranceReportService?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/EntranceService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/EntranceService.kt
@@ -116,6 +116,6 @@ class EntranceService(private val client: IngresseClient) {
         }
 
         val type = object: TypeToken<Response<Array<GuestJSON>>>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/EventDetailsService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/EventDetailsService.kt
@@ -89,6 +89,6 @@ class EventDetailsService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<EventDetailsJSON>?>() {}.type
-        mGetEventDetailsCall?.enqueue(RetrofitCallback(type, callback))
+        mGetEventDetailsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/EventService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/EventService.kt
@@ -141,7 +141,7 @@ class EventService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponseHits<EventJSON>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -199,7 +199,7 @@ class EventService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<DataJSON<EventJSON>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -248,6 +248,6 @@ class EventService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<DataJSON<EventJSON>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/HighlightService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/HighlightService.kt
@@ -118,6 +118,6 @@ class HighlightService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponsePaged<HighlightEventJSON>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/HistoryService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/HistoryService.kt
@@ -92,7 +92,7 @@ class HistoryService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<DataArray<CheckinHistoryJSON>?>>() {}.type
-        mGetCheckinHistoryCall?.enqueue(RetrofitCallback(type, callback))
+        mGetCheckinHistoryCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -134,6 +134,6 @@ class HistoryService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<DataArray<TransferHistoryItemJSON>?>>() {}.type
-        mGetTransferHistoryCall?.enqueue(RetrofitCallback(type, callback))
+        mGetTransferHistoryCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/POSService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/POSService.kt
@@ -106,7 +106,7 @@ class POSService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponseSellTickets>() {}.type
-        mSellTicketsCall?.enqueue(RetrofitCallback(type, callback))
+        mSellTicketsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -144,7 +144,7 @@ class POSService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponsePrintTickets>() {}.type
-        mPrintTicketsCall?.enqueue(RetrofitCallback(type, callback))
+        mPrintTicketsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -176,7 +176,7 @@ class POSService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponsePrintLog>() {}.type
-        mPrintTicketsCall?.enqueue(RetrofitCallback(type, callback))
+        mPrintTicketsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -213,7 +213,7 @@ class POSService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<PlannerAttributesJSON>>() {}.type
-        mGetPlannerAttributesCall?.enqueue(RetrofitCallback(type, callback))
+        mGetPlannerAttributesCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -252,7 +252,7 @@ class POSService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponseValidateTickets>() {}.type
-        mValidateTicketsCall?.enqueue(RetrofitCallback(type, callback))
+        mValidateTicketsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
 

--- a/sdk/src/main/java/com/ingresse/sdk/services/PermissionService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/PermissionService.kt
@@ -81,6 +81,6 @@ class PermissionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<SalesGroupResponse>() {}.type
-        mSalesGroupCall?.enqueue(RetrofitCallback(type, callback))
+        mSalesGroupCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/PhoneService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/PhoneService.kt
@@ -76,6 +76,6 @@ class PhoneService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<CountryResponse>() {}.type
-        mGetCountriesCall?.enqueue(RetrofitCallback(type, callback))
+        mGetCountriesCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/ReportService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/ReportService.kt
@@ -105,7 +105,7 @@ class ReportService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<VisitsReportJSON>?>() {}.type
-        mGetVisitsReportService?.enqueue(RetrofitCallback(type, callback))
+        mGetVisitsReportService?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
 
@@ -141,7 +141,7 @@ class ReportService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponseSessionDashboard>() {}.type
-        mGetSessionDashboardCall?.enqueue(RetrofitCallback(type, callback))
+        mGetSessionDashboardCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -178,6 +178,6 @@ class ReportService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ResponseSalesTimeline>() {}.type
-        mGetSalesTimelineCall?.enqueue(RetrofitCallback(type, callback))
+        mGetSalesTimelineCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/SearchService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/SearchService.kt
@@ -126,6 +126,6 @@ class SearchService(private val client: IngresseClient) {
         }
 
         val type = object: TypeToken<ResponseHits<EventJSON>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/TicketListService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/TicketListService.kt
@@ -107,6 +107,6 @@ class TicketListService(private val client: IngresseClient) {
         }
 
         val type = object: TypeToken<ResponseDataPaged<ArrayList<Responses.GroupJSON>>>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/TicketService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/TicketService.kt
@@ -109,7 +109,7 @@ class TicketService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<Array<TicketGroupJSON>>?>() {}.type
-        mGetEventTicketsCall?.enqueue(RetrofitCallback(type, callback))
+        mGetEventTicketsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -154,7 +154,7 @@ class TicketService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<CreateTransferJSON>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -207,6 +207,6 @@ class TicketService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<AuthenticationUserDeviceJSON>?>() {}.type
-        mAuthenticationUserDeviceCall?.enqueue(RetrofitCallback(type, callback))
+        mAuthenticationUserDeviceCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/TicketStatusService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/TicketStatusService.kt
@@ -95,6 +95,6 @@ class TicketStatusService(val client: IngresseClient, timeout: Long = 2) {
         }
 
         val type = object: TypeToken<Response<Array<CheckinSessionJSON>>>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/TransactionService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/TransactionService.kt
@@ -131,7 +131,7 @@ class TransactionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<CreateTransactionJSON>?>() {}.type
-        mCreateTransactionCall?.enqueue(RetrofitCallback(type, callback))
+        mCreateTransactionCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -173,7 +173,7 @@ class TransactionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<TransactionDetailsJSON>?>() {}.type
-        mGetTransactionDetailsCall?.enqueue(RetrofitCallback(type, callback))
+        mGetTransactionDetailsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -211,7 +211,7 @@ class TransactionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<TransactionDetailsJSON>?>() {}.type
-        mCancelTransactionCall?.enqueue(RetrofitCallback(type, callback))
+        mCancelTransactionCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -252,7 +252,7 @@ class TransactionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<TransactionReportJSON>?>() {}.type
-        mGetTransactionReportCall?.enqueue(RetrofitCallback(type, callback))
+        mGetTransactionReportCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -295,7 +295,7 @@ class TransactionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<Array<TransactionJSON>?>>() {}.type
-        mGetTransactionListCall?.enqueue(RetrofitCallback(type, callback))
+        mGetTransactionListCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -356,7 +356,7 @@ class TransactionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<Array<TransactionJSON>>?>() {}.type
-        mGetTransactionsCall?.enqueue(RetrofitCallback(type, callback))
+        mGetTransactionsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -398,7 +398,7 @@ class TransactionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<TransactionJSON>?>() {}.type
-        mGetDetailsCall?.enqueue(RetrofitCallback(type, callback))
+        mGetDetailsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -434,7 +434,7 @@ class TransactionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<DataArray<String>>?>() {}.type
-        mGetRefundReasonsCall?.enqueue(RetrofitCallback(type, callback))
+        mGetRefundReasonsCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -476,6 +476,6 @@ class TransactionService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<TransactionDetailsRefundJSON>?>() {}.type
-        mRefundTransactionCall?.enqueue(RetrofitCallback(type, callback))
+        mRefundTransactionCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/TransferService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/TransferService.kt
@@ -149,7 +149,7 @@ class TransferService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<Array<UserTransfersJSON>>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -195,7 +195,7 @@ class TransferService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<List<RecentTransfersJSON>>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -240,7 +240,7 @@ class TransferService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<List<FriendsFromSearchJSON>>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -286,7 +286,7 @@ class TransferService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<UpdateTransferJSON>?>() {}.type
-        mUpdateTransferCall?.enqueue(RetrofitCallback(type, callback))
+        mUpdateTransferCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -329,7 +329,7 @@ class TransferService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<ReturnTicketJSON>?>() {}.type
-        mReturnTicketCall?.enqueue(RetrofitCallback(type, callback))
+        mReturnTicketCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -373,6 +373,6 @@ class TransferService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<TransferTicketJSON>?>() {}.type
-        mTransferTicketCall?.enqueue(RetrofitCallback(type, callback))
+        mTransferTicketCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/UserService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/UserService.kt
@@ -209,7 +209,7 @@ class UserService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<UserDataJSON>>() {}.type
-        mUserDataCall?.enqueue(RetrofitCallback(type, callback))
+        mUserDataCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -271,7 +271,7 @@ class UserService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<UserUpdatedJSON>>() {}.type
-        mUpdateBasicInfosCall?.enqueue(RetrofitCallback(type, callback))
+        mUpdateBasicInfosCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -325,7 +325,7 @@ class UserService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<UserUpdatedJSON>>() {}.type
-        mUpdateUserPictureCall?.enqueue(RetrofitCallback(type, callback))
+        mUpdateUserPictureCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -387,7 +387,7 @@ class UserService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<UserUpdatedJSON>?>() {}.type
-        mUpdateUserAddressCall?.enqueue(RetrofitCallback(type, callback))
+        mUpdateUserAddressCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -447,7 +447,7 @@ class UserService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<UserUpdatedJSON>?>() {}.type
-        mUpdateUserPlannerInfosCall?.enqueue(RetrofitCallback(type, callback))
+        mUpdateUserPlannerInfosCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -519,7 +519,7 @@ class UserService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<Array<UserTicketsJSON>>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -572,7 +572,7 @@ class UserService(private val client: IngresseClient) {
             override fun onTokenExpired() = onTokenExpired()
         }
         val type = object : TypeToken<Response<EventAttributesJSON>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -639,7 +639,7 @@ class UserService(private val client: IngresseClient) {
             override fun onTokenExpired() = onTokenExpired()
         }
         val type = object : TypeToken<Response<Array<WalletEventJSON>>?>() {}.type
-        call.enqueue(RetrofitCallback(type, callback))
+        call.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -700,7 +700,7 @@ class UserService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<StrengthPasswordJSON?>>() {}.type
-        mValidatePasswordStrengthCall?.enqueue(RetrofitCallback(type, callback))
+        mValidatePasswordStrengthCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -743,7 +743,7 @@ class UserService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Ignored>() {}.type
-        mChangePasswordCall?.enqueue(RetrofitCallback(type, callback))
+        mChangePasswordCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 
     /**
@@ -795,6 +795,6 @@ class UserService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<Response<DataJSON<CreateAccountJSON>>?>() {}.type
-        mCreateAccountCall?.enqueue(RetrofitCallback(type, callback))
+        mCreateAccountCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }

--- a/sdk/src/main/java/com/ingresse/sdk/services/ZipCodeService.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/services/ZipCodeService.kt
@@ -81,6 +81,6 @@ class ZipCodeService(private val client: IngresseClient) {
         }
 
         val type = object : TypeToken<ZipCodeAddressJSON?>() {}.type
-        mZipCodeCall?.enqueue(RetrofitCallback(type, callback))
+        mZipCodeCall?.enqueue(RetrofitCallback(type, callback, client.logger))
     }
 }


### PR DESCRIPTION
### Problema
- Atualmente não temos visibilidade de quando alguma request volta com um status code que não seja de sucesso
- O campo `responseStatus` do objeto `Error` espera sempre que o `responseStatus` recebido da API seja um inteiro, porém às vezes recebemos uma string

### Solução
- Adicionar uma classe de logger onde o app que utiliza o SDK pode injetar esse log no client e gerenciar como logar essas requests com erro
- Remover propriedade não utilizada 

