### PR TITLE
[Feature] Envio do ID da transação do terminal POS

### DIFF
--- a/sdk/src/main/java/com/ingresse/sdk/model/request/SellTickets.kt
+++ b/sdk/src/main/java/com/ingresse/sdk/model/request/SellTickets.kt
@@ -23,13 +23,15 @@ data class POSTerminal(
     var vendor: String = "",
     var externalId: String = "",
     var authorizationCode: String = "",
-    var nsu: String = ""): Parcelable {
+    var nsu: String = "",
+    var acquirerTransactionId: String = ""): Parcelable {
 
     constructor(parcel: Parcel) : this() {
         vendor = parcel.readString().orEmpty()
         externalId = parcel.readString().orEmpty()
         authorizationCode = parcel.readString().orEmpty()
         nsu = parcel.readString().orEmpty()
+        acquirerTransactionId = parcel.readString().orEmpty()
     }
 
     override fun writeToParcel(parcel: Parcel, flags: Int) {
@@ -37,6 +39,7 @@ data class POSTerminal(
         parcel.writeString(externalId)
         parcel.writeString(authorizationCode)
         parcel.writeString(nsu)
+        parcel.writeString(acquirerTransactionId)
     }
 
     override fun describeContents(): Int =  0


### PR DESCRIPTION
## Objetivo
Realizar o envio do ID da transação junto com as demais informações da venda realizada num terminal.

### Contexto

Para conseguir validar o pagamento realizado em um terminal junto a adquirente com a venda da Ingresse, é necessário enviar o ID da transação para que este dado seja repassado a API/backend responsável em realizar a venda ligada ao terminal.

PS: Importante para a feature Tap to Pay para associar a venda do terminal com a conclusão/confirmação de venda da Ingresse.